### PR TITLE
s/te/t/g

### DIFF
--- a/src/tcore.erl
+++ b/src/tcore.erl
@@ -48,7 +48,7 @@ eval({t, Es}, I, E, K, D, W, T) ->
       {Dims, MaxT};
     {false, Dis1} ->
       Tuple = lists:zip(odd_elements(Dis1), even_elements(Dis1)),
-      {{te, Tuple}, MaxT}
+      {{t, Tuple}, MaxT}
   end;
 
 %%-------------------------------------------------------------------------------------
@@ -60,7 +60,7 @@ eval({'@', E0, E1}, I, E, K, D, W, T) ->
     true ->
       {lists:filter(fun tset:is_d/1, Di), T1};
     false ->
-      {te, Di2} = Di,
+      {t, Di2} = Di,
       Ki = tset:perturb(K, Di2),
       Di3 = tset:union(D, tset:domain(Di2)),
       eval(E0, I, E, Ki, Di3, W, T1)

--- a/test/tea_tests.erl
+++ b/test/tea_tests.erl
@@ -48,7 +48,7 @@ tuple1_test () ->
     K = [{TimeD,100}, {SpaceD,100}],
     D = [TimeD,SpaceD],
     tcache:start_link(100),
-    ?assertMatch({{te,[{TimeD,1},{SpaceD,2}]}, _}, % Uh? ‘te’? Is just ‘t’ the same?
+    ?assertMatch({{t,[{TimeD,1},{SpaceD,2}]}, _}, % Uh? ‘te’? Is just ‘t’ the same?
         tcore:eval(Tree, [],[],K, D, [0], 0)).
 
 tuple2_test () ->


### PR DESCRIPTION
Hey Ed,

I don't know if that was a typo in `src/tcore.erl` as it still works…
Maybe we should not merge that?

Cheers
