### PR TITLE
Solve possible calc value returned by evaluation of var id

### DIFF
--- a/src/tcore.erl
+++ b/src/tcore.erl
@@ -216,8 +216,7 @@ eval({phi,Xi}=Di, _I, _E, _K, _D, _W, T) when is_list(Xi) orelse is_atom(Xi) ->
 %% Variable Identifiers
 %%-------------------------------------------------------------------------------------
 eval(Xi, I, E, K, D, W, T) when is_list(Xi) orelse is_atom(Xi) ->
-  {_D0, _T0} = eval1(Xi, I, E, K, [], W, T),
-  tcache:find(Xi, K, D, W, T).
+  {_D0, _T0} = eval1(Xi, I, E, tset:restrict_domain(K, D), [], W, T).
 
 %%-------------------------------------------------------------------------------------
 %% Finding identifiers in the cache


### PR DESCRIPTION
The cache semantics (as specified in the Feb 2013 paper) is wrong as
it does not guarantee that rule (9) (i.e. eval) returns a value (or
list of missing dimensions) - it could return a calc! (... that would
blow up the rule that called this rule)

The problem is that in rule (9) there is a separate final call to
beta.find, that assumes that the chain just written by rule (10) and,
ultimately, by rule (11) was not garbage collected (this assumption is
wrong for concurrency among threads in the interaction with the
cache).

The solution is modifying rule (9):
- Remove beta.find, i.e. return the result of rule (10) eval1; and
- Do not pass the full context k but k restricted to the set of known
  dimensions.

This solution implies that when the chain of a variable is being
computed by rule (10), i.e. eval1, the chain will be built only using
the subset of the context that is known.
