### PR TITLE
DO NOT MERGE - Get rid of the cache's clock T

### DIFF
--- a/src/ice.erl
+++ b/src/ice.erl
@@ -11,7 +11,7 @@
 eval(T) ->
   T0 = ice_t0:transform(T),
   T1 = ice_t1:transform(T0),
-  ice_core:eval(T1,[],[],[],[],{[],self()},0).
+  {ice_core:eval(T1,[],[],[],[],{[],self()}), fake_clock}.
 
 -spec i(string()) -> term().
 i(String) ->

--- a/src/ice_cache.erl
+++ b/src/ice_cache.erl
@@ -2,7 +2,7 @@
 
 %% ice_cache interface exports
 -export([create/0, delete/0]).
--export([find/5, add/6]).
+-export([find/4, add/5]).
 
 -define(FMT_D(V), %% Format missing dimensions
         case V of
@@ -27,35 +27,35 @@ delete() ->
 %%------------------------------------------------------------------------------
 %% @doc Find an identifier with a specific context K restricted by the domain D
 %%------------------------------------------------------------------------------
-find(X, K, D, {Id0, _} = W0, _T) ->
+find(X, K, D, {Id0, _} = W0) ->
   KD = ice_dtree:sort_context(ice_sets:restrict_domain(K, D)),
   case ice_dtree:insert_new({X,KD}, {calc,W0}) of
     {true, {calc,W0}} ->
       %% io:format("Inserted X = ~p, KD = ~p, {calc, ~p}~n", [X, KD, W0]),
-      {{calc,W0}, 0};
-    {false, {calc, {Id1,_} = W1} = V} ->
+      {calc,W0};
+    {false, {calc, {Id1,_} = _W1} = V} ->
       case lists:prefix(Id1, Id0) of
         true ->
           hang;
         false ->
           %% io:format("Found X = ~p, KD = ~p, {calc, ~p}~n", [X, KD, W1]),
-          {V, 0}
+          V
       end;
     {false, V} ->
       %% io:format("Found X = ~p, KD = ~p, " ++ ?FMT_D(V) ++ "~n", [X,KD,V]),
-      {V, 0}
+      V
   end.
 
 %%------------------------------------------------------------------------------
 %% @doc Add an {identifier, context, value} to the cache
 %%------------------------------------------------------------------------------
-add(X, K, D, W, _T, V) ->
+add(X, K, D, W, V) ->
   KD = ice_dtree:sort_context(ice_sets:restrict_domain(K, D)),
   case ice_dtree:lookup({X,KD}) of
     {calc, W} ->
       %% io:format("Inserting X = ~p, KD = ~p, " ++ ?FMT_D(V) ++ "~n", [X,KD,V]),
       true = ice_dtree:insert({X,KD}, V),
-      {V, 0};
+      V;
     _ ->
       hang
   end.

--- a/src/ice_par.erl
+++ b/src/ice_par.erl
@@ -3,40 +3,30 @@
 %%-------------------------------------------------------------------------------------
 -module(ice_par).
 
--export([eval/7, eval_seq/7]).
+-export([eval/6, eval_seq/6]).
 
 %%------------------------------------------------------------------------------
 %% @doc Evaluate expressions in parallel
 %%
 %% The order of the evaluated results is guaranteed to be the same as
 %% the order of the expressions specified.
-%% ------------------------------------------------------------------------------
-eval(Xs, I, E, K, D, W, T) ->
+%%------------------------------------------------------------------------------
+eval(Xs, I, E, K, D, W) ->
   Lim = length(Xs),
   %%------------------------------------------------------------------------------
   %% Note: Passing self() here means W is self()
   %%------------------------------------------------------------------------------
   Pids = ice_thread:spawn_n(W, Lim),
-  ice_thread:join(Pids, Xs, I, E, K, D, W, T).
+  ice_thread:join(Pids, Xs, I, E, K, D, W).
 
 %%-------------------------------------------------------------------------------------
 %% @doc Evaluate a sequence expressions 
 %%-------------------------------------------------------------------------------------
-eval_seq(Xs, I, E, K, D, W, T) ->
-  eval_seq(Xs, I, E, K, D, W, T, []).
+eval_seq(Xs, I, E, K, D, W) ->
+  eval_seq(Xs, I, E, K, D, W, []).
 
-eval_seq([], I, E, K, D, W, T, Acc) ->
-  {lists:reverse(Acc), T};
-eval_seq([X|Xs], I, E, K, D, W, T, Acc) ->
-  {D0, T1} = ice_core:eval(X, I, E, K, D, W, T),
-  case T1 > T of
-    true ->
-      eval_seq(Xs, I, E, K, D, W, T1, [D0|Acc]);
-    false ->
-      eval_seq(Xs, I, E, K, D, W, T, [D0|Acc])
-  end.
-
-
-
-
-
+eval_seq([], _I, _E, _K, _D, _W, Acc) ->
+  lists:reverse(Acc);
+eval_seq([X|Xs], I, E, K, D, W, Acc) ->
+  D0 = ice_core:eval(X, I, E, K, D, W),
+  eval_seq(Xs, I, E, K, D, W, [D0|Acc]).

--- a/test/contextual_semantics_tests.erl
+++ b/test/contextual_semantics_tests.erl
@@ -214,8 +214,8 @@ var_recursing_on_input_outer_dim() ->
 mock_ice_par() ->
   ok = meck:new(ice_par, [passthrough]),
   ok = meck:expect(ice_par, eval,
-                   fun(Xs, I, E, K, D, W, T) ->
-                       ice_par:eval_seq(Xs, I, E, K, D, W, T)
+                   fun(Xs, I, E, K, D, W) ->
+                       ice_par:eval_seq(Xs, I, E, K, D, W)
                    end).
 
 unmock_ice_par() ->

--- a/test/id_tests.erl
+++ b/test/id_tests.erl
@@ -365,8 +365,8 @@ var_redefined_in_nested_wherevar_is_shadowed_by_outer_if_outer_already_queried()
 mock_ice_par() ->
   ok = meck:new(ice_par, [passthrough]),
   ok = meck:expect(ice_par, eval,
-                   fun(Xs, I, E, K, D, W, T) ->
-                       ice_par:eval_seq(Xs, I, E, K, D, W, T)
+                   fun(Xs, I, E, K, D, W) ->
+                       ice_par:eval_seq(Xs, I, E, K, D, W)
                    end).
 
 unmock_ice_par() ->

--- a/test/tclosure_negative_tests.erl
+++ b/test/tclosure_negative_tests.erl
@@ -126,8 +126,8 @@ tests_w_b_abs_from_various_expressions(A=_UndefVarIdA, T=_ASTGenF) ->
 mock_ice_par() ->
   ok = meck:new(ice_par, [passthrough]),
   ok = meck:expect(ice_par, eval,
-                   fun(Xs, I, E, K, D, W, T) ->
-                       ice_par:eval_seq(Xs, I, E, K, D, W, T)
+                   fun(Xs, I, E, K, D, W) ->
+                       ice_par:eval_seq(Xs, I, E, K, D, W)
                    end).
 
 unmock_ice_par() ->

--- a/test/where_tests.erl
+++ b/test/where_tests.erl
@@ -84,8 +84,8 @@ dim_cannot_use_var_in_same_where() ->
 mock_ice_par() ->
   ok = meck:new(ice_par, [passthrough]),
   ok = meck:expect(ice_par, eval,
-                   fun(Xs, I, E, K, D, W, T) ->
-                       ice_par:eval_seq(Xs, I, E, K, D, W, T)
+                   fun(Xs, I, E, K, D, W) ->
+                       ice_par:eval_seq(Xs, I, E, K, D, W)
                    end).
 
 unmock_ice_par() ->


### PR DESCRIPTION
The ice:eval/1 function preserves the {term(), T} return value in
order not to update most tests at the moment.

Unit tests fail.  Further thought needs to be spent on this change as
actually the {term(), T} type in the core code (ice_core, ...) was
used for stopping execution as soon as possible with a badmatch in
case of cache hangs (and other errors maybe).
