### PR TITLE
ICE shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ deps
 erl_crash.dump
 src/ice_parse.erl
 src/ice_scan.erl
+bin/ice_shell

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ debug: compile
 	erl -pa ebin -pa deps/*/ebin -env ERL_MAX_ETS_TABLES 256000
 .PHONY: debug
 
+shell: compile
+	./bin/icesh
+.PHONY: shell
+
 test: compile
 	./rebar skip_deps=true eunit
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,17 @@ debug: compile
 	erl -pa ebin -pa deps/*/ebin -env ERL_MAX_ETS_TABLES 256000
 .PHONY: debug
 
-shell: compile
+shell: bin/ice_shell
 	./bin/icesh
 .PHONY: shell
 
 test: compile
 	./rebar skip_deps=true eunit
 .PHONY: test
+
+bin/ice_shell: compile
+	./rebar escriptize
+	mv ice_shell bin/ice_shell
 
 # Grammar compilation / debugging
 ANTLR4_JAR=antlr-4.1-complete.jar

--- a/bin/icesh
+++ b/bin/icesh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # start an ICE shell session
 
-ice_root="`dirname $0`/.."
+ice_root="`dirname $0`"
 
 if rlwrap -v >/dev/null 2>&1
   then
@@ -10,5 +10,5 @@ if rlwrap -v >/dev/null 2>&1
 	else  RL=rlwrap; fi
   else RL=''; fi
 
-$RL erl -pa "$ice_root/ebin" -noshell -s ice_shell -extra "$@"
+exec $RL "$ice_root/ice_shell" "$@"
 

--- a/bin/icesh
+++ b/bin/icesh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# start an ICE shell session
+
+ice_root="`dirname $0`/.."
+
+if rlwrap -v >/dev/null 2>&1
+  then
+	if [ "$TERM" == dumb ]; then RL=''
+	elif  [ "$TERM" == emacs ]; then RL=''
+	else  RL=rlwrap; fi
+  else RL=''; fi
+
+$RL erl -pa "$ice_root/ebin" -noshell -s ice_shell -extra "$@"
+

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
 %% -*- erlang -*-
 
 {deps, [ {meck, ".*", {git, "git@github.com:eproxus/meck.git"}} ]}.
+
+{escript_name,"ice_shell"}.

--- a/src/ice_pp.erl
+++ b/src/ice_pp.erl
@@ -1,0 +1,65 @@
+-module(ice_pp).
+
+-export([pretty_print/1]).
+
+%% API
+
+pretty_print (AST) ->
+    lists:flatten(pp(AST, 0)).
+
+%% Internals
+
+s (N) -> string:chars($ , 2 * N).   %% Prepend spaces (Tab width * N).
+%% es (T) -> [S] = io_lib:format("~p",[T]), S.   %% Ensure T is string().
+
+pp({var_decl, _, {id, Name}, Body}, N) ->
+	["var ", Name, " =\n", s(N+1), pp(Body, N+2),"\n"];
+
+pp({dim_decl, _, {id, Name}, Body}, N) ->
+	["dim ", Name, " <- ", pp(Body, N),"\n"];
+
+pp({fun_decl, _, {id, Name}, Params,Body}, N) ->
+	["fun ", Name, 
+		[[".", pp(BP, N)] || {b_param, BP} <- Params],
+		[[" ", pp(NP, N)] || {n_param, NP} <- Params],
+		" =\n", s(N+1), pp(Body, N+2),"\n"];
+
+pp({int, V}, _) -> integer_to_list(V);
+pp({float, V}, _) -> io_lib:format("~ff0", [V]);
+pp({char, V}, _) -> io_lib:format("'~s'", [[V]]);
+pp({string, V}, _) -> io_lib:format("\"~s\"", [V]);
+pp({bool, V}, _) -> io_lib:format("~s", [V]);
+
+pp({id, V}, _) -> io_lib:format("~s", [V]);
+pp({'#', X}, N) -> 
+	["#.", pp(X, N)];
+
+pp({primop, O, [A, B]}, N) ->
+	["(",pp(A, N),  io_lib:format(" ~s ", [O]), pp(B,N), ")"];
+pp({primop, O, Es}, N) ->
+	[io_lib:format(" ~s(", [O]), [[" ", pp(E, N)] || E <- Es] , " ) "];
+
+pp({t, Es}, N) ->
+	["[", string:join([lists:flatten([pp(Dim, N), " <- ", pp(E, N)]) || {Dim, E} <- Es], ", "), "]"];
+
+pp({'@', A, B}, N) ->
+	[pp(A, N), " @ ", pp(B,N)];
+
+pp({'if', A, B, C}, N) ->
+	["if ", pp(A, N),
+	 "\n", s(N+1), "then\n",
+	s(N+2), pp(B, N+2),
+	 "\n", s(N+1), "else\n",
+	s(N+2), pp(C, N+2),
+	"\n", s(N), "fi"];
+
+pp({fn_call, Name, Params}, N) ->
+	["(", pp(Name, N), 
+		[[".", pp(BP, N)] || {b_param, BP} <- Params],
+		[[" ", pp(NP, N)] || {n_param, NP} <- Params],
+	")"];
+
+pp(X, _N) ->
+	io_lib:format("~p", [X]).
+
+

--- a/src/ice_shell.erl
+++ b/src/ice_shell.erl
@@ -1,0 +1,143 @@
+-module(ice_shell).
+-export([start/0]).
+
+-record(state, {prompt= "", cache = clear, defs = []}).
+
+start() ->
+    error_logger:tty(false),
+    Prompt = case io:columns() of
+       {ok, _} -> "ICE> ";
+       {error, enotsup} -> ""
+    end,
+    loop(#state{prompt = Prompt}).
+
+loop(#state{prompt = P} = S) ->
+    case io:get_line(P) of
+        eof -> init:stop();
+        {error, _} -> init:stop();
+        Line ->
+            do_line(Line, S)
+    end.
+
+do_line(L, #state{defs = Defs, cache = C} = S) ->
+    case check_line(L) of
+        empty ->
+            loop(S);
+        {def, {Name, _} = D} ->
+            NewDefs = lists:keystore(Name, 1, Defs, D),
+            loop(#state{defs = NewDefs});
+        {query, Q} ->
+            Query = Q ++ where_defs(Defs),
+            try
+		{Res, _} = eval(Query, C),
+                io:format("~p\n", [Res]),
+                loop(S)
+            catch Class:Err ->
+                io:format("*** ~p:~p in ~s\n~p\n", [Class,Err, Query, erlang:get_stacktrace()]),
+                catch ice_cache:delete(),
+                loop(S#state{cache = clear})
+            end;
+        {command, d} ->
+            loop(S#state{defs = []});
+        {command, q} ->
+            init:stop();
+        {command, p} ->
+            print(Defs),
+            loop(S);
+        {command, {l, Name}} ->
+            loop(S#state{defs = load(Name, Defs)});
+        {command, cache_on} ->
+            ice_cache:create(),
+            loop(S#state{cache = keep});
+        {command, cache_off} ->
+             ice_cache:delete(),
+            loop(S#state{cache = clear});
+        {command, print_cache_state} ->
+            io:format("***cache ~p\n", [C]),
+            loop(S);
+         {badcommand, C} ->
+            io:format("*** Bad command: `~s'\n", [C]),
+            loop(S)
+    end.
+
+check_line(S) ->
+    case re:run(S, "^\\s*(//.*)?$") of
+        nomatch ->
+            check_command(S);
+        _ ->
+            empty
+    end.
+
+check_command(S) ->
+    case re:run(S, "^:(\\w+)\\s+(.*)", [{capture, [1,2], list}]) of
+        {match, ["d", ""]} ->
+            {command, d};
+        {match, ["p", ""]} ->
+            {command, p};
+        {match, ["q", ""]} ->
+            {command, q};
+        {match, ["c", OnOff]} ->
+            case string:strip(OnOff) of
+                "on"++ _ ->
+                    {command, cache_on};
+                 "off" ++ _ ->
+                     {command, cache_off};
+                 _ ->
+                     {command, print_cache_state}
+             end;
+        {match, ["l", File]} ->
+            {command, {l, File}};
+        {match, [C|_]} ->
+            {badcommand, C};
+        nomatch ->
+            check_def(S)
+    end.
+
+check_def(S) ->
+    case re:run(S, "^\\s*(fun|var|dim)\\s+(\\w+)", [{capture, [2],list}]) of
+        {match, [Name]} ->
+            {def, {Name, S}};
+        nomatch ->
+            {query, S}
+    end.
+
+load(Name, OrigDefs) ->
+    try
+        {ok, Bin} = file:read_file(Name),
+        lists:foldl(fun do_file_line/2,
+                    OrigDefs,
+                    [S ++ "\n" || S <- string:tokens(binary_to_list(Bin), "\n")])
+    catch _ : E ->
+            io:format("*** error while loading  `~s': ~p\n", [Name, E]),
+            OrigDefs
+    end.
+
+do_file_line(L, Defs) ->
+    case check_line(L) of
+        empty ->
+            Defs;
+        {def, {Name, _} = D} ->
+            lists:keystore(Name, 1, Defs, D);
+        Other ->
+            throw(Other)
+    end.
+
+where_defs(Defs) ->
+    XDefs = [Def || {_Name, Def} <- Defs],
+    lists:flatten(["  where\n\t", string:join(XDefs, "\t"), "  end\n"]).
+
+print(Defs) ->
+    [io:format("~s", [Def]) || {_Name, Def} <- Defs],
+    ok.
+
+eval(String, C) ->
+    Tree = ice_string:parse(String),
+    case C of
+              clear ->
+                  ice_cache:create(),
+                  Res = ice:eval(Tree),
+                  ice_cache:delete(),
+                  Res;
+              keep ->
+                  ice:eval(Tree)
+              end.

--- a/src/ice_shell.erl
+++ b/src/ice_shell.erl
@@ -1,5 +1,5 @@
 -module(ice_shell).
--export([start/0]).
+-export([start/0, main/1]).
 
 -record(state, {prompt= "",
                 prompt2 = "",
@@ -7,8 +7,12 @@
                 defs = [],
                 tstamp = os:timestamp()}).
 
+
 start() ->
     Args = init:get_plain_arguments(),
+    main(Args).
+
+main(Args) ->
     {Lines, Files} = arg_parse(Args, [], []),
     S0 = load_files(Files, #state{}),
     error_logger:tty(false),
@@ -97,7 +101,7 @@ do_line(L, #state{defs = Defs, cache = C, tstamp = TStamp} = S) ->
         {command, d} ->
             S#state{defs = []};
         {command, q} ->
-            init:stop();
+            {quit, S};
         {command, p} ->
             print(Defs),
             S;

--- a/src/ice_shell.erl
+++ b/src/ice_shell.erl
@@ -197,7 +197,7 @@ expr_where_defs(Expr, Defs) ->
     ice_ast:transform([{expr, 0, {where, 0, Expr, Dims, Vars}}]).
 
 print(Defs) ->
-    [io:format("~s ~s: ~p\n", [T, Name, Def]) || {Name, T, Def} <- Defs],
+    [io:format("~s\n", [ice_pp:pretty_print(ice_ast:transform([Def]))]) || {_Name, _T, Def} <- Defs],
     ok.
 
 do_query(Q, #state{defs = Defs} = S, TC) ->
@@ -224,6 +224,9 @@ new_cache() ->
     try ice_cache:delete() of
         true ->
             ice_cache:create()
-    catch exit:{noproc, _} ->
+    catch 
+          exit:{noproc, _} ->
+              ice_cache:create();
+         _:{badmatch, {aborted, _}} -> %% Mnesia
             ice_cache:create()
     end.


### PR DESCRIPTION
- var|dim|fun definitions are appended to an implicit WHERE-clause
- re-defining an identifier replaces the old definition
- expressions evaluated using the global WHERE-clause
- commands:
    - `:q` Quit
    - `:d` Delete all definitions
    - `:p` Print definitions
    - `:l FILE` load definitions from FILE (has to contain defs)

Close #70
